### PR TITLE
gobig_dir argument to find images and prompts from directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.egg-info/
 out/
 *.ckpt
+my_settings.json

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,19 +1,6 @@
 apt-get update
-apt-get --assume-yes install screen zip libglib2.0-0 libsm6 libxext6 libxrender1
-wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh
-chmod a+x Miniconda3-latest-Linux-x86_64.sh
-./Miniconda3-latest-Linux-x86_64.sh -b -p /workspace/conda
-/workspace/conda/bin/conda init
-cp /root/.bashrc /workspace/.bashrc
-. /workspace/.bashrc
-if [ ! -f /path/to/file ]; then
-    wget $SD_MODEL_URL
-fi
+apt-get --assume-yes install screen zip
 git clone https://github.com/janekm/progrock-stable.git
-cd progrock-stable
-conda env create -f environment.yaml
-conda activate prs
-cd ..
 git clone https://github.com/xinntao/Real-ESRGAN.git
 cd Real-ESRGAN
 pip install -r requirements.txt
@@ -26,4 +13,6 @@ wget $IN_FILES_ZIP_URL
 unzip gobig_in.zip
 ln ../model.ckpt models/sd-v1-4.ckpt
 python prs.py --gobig_dir gobig_in -s my_settings.json
+zip out.zip ./out/Default/*
+
 # bash -c "sleep infinity"

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,0 +1,25 @@
+apt-get update
+apt-get --assume-yes install screen zip libglib2.0-0 libsm6 libxext6 libxrender1
+wget https://podfilesjanek.s3.eu-west-1.amazonaws.com/Miniconda3-latest-Linux-x86_64.sh
+chmod a+x Miniconda3-latest-Linux-x86_64.sh
+./Miniconda3-latest-Linux-x86_64.sh -b -p /workspace/conda
+/workspace/conda/bin/conda init
+cp /root/.bashrc /workspace/.bashrc
+. /workspace/.bashrc
+wget $SD_MODEL_URL
+git clone https://github.com/janekm/progrock-stable.git
+cd progrock-stable
+conda env create -f environment.yaml
+conda activate prs
+cd ..
+git clone https://github.com/xinntao/Real-ESRGAN.git
+cd Real-ESRGAN
+pip install -r requirements.txt
+python setup.py develop
+wget https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models
+cd ../progrock-stable
+wget $SETTINGS_URL
+wget $IN_FILES_ZIP_URL
+unzip gobig_in.zip
+python prs.py --gobig_dir gobig_in -s my_settings.json
+# bash -c "sleep infinity"

--- a/install_script.sh
+++ b/install_script.sh
@@ -1,12 +1,14 @@
 apt-get update
 apt-get --assume-yes install screen zip libglib2.0-0 libsm6 libxext6 libxrender1
-wget https://podfilesjanek.s3.eu-west-1.amazonaws.com/Miniconda3-latest-Linux-x86_64.sh
+wget https://repo.anaconda.com/miniconda/Miniconda3-py39_4.12.0-Linux-x86_64.sh
 chmod a+x Miniconda3-latest-Linux-x86_64.sh
 ./Miniconda3-latest-Linux-x86_64.sh -b -p /workspace/conda
 /workspace/conda/bin/conda init
 cp /root/.bashrc /workspace/.bashrc
 . /workspace/.bashrc
-wget $SD_MODEL_URL
+if [ ! -f /path/to/file ]; then
+    wget $SD_MODEL_URL
+fi
 git clone https://github.com/janekm/progrock-stable.git
 cd progrock-stable
 conda env create -f environment.yaml
@@ -15,11 +17,13 @@ cd ..
 git clone https://github.com/xinntao/Real-ESRGAN.git
 cd Real-ESRGAN
 pip install -r requirements.txt
+pip install omegaconf
 python setup.py develop
 wget https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -P experiments/pretrained_models
 cd ../progrock-stable
 wget $SETTINGS_URL
 wget $IN_FILES_ZIP_URL
 unzip gobig_in.zip
+ln ../model.ckpt models/sd-v1-4.ckpt
 python prs.py --gobig_dir gobig_in -s my_settings.json
 # bash -c "sleep infinity"

--- a/prs.py
+++ b/prs.py
@@ -100,9 +100,9 @@ def do_run(device, model, opt):
     seed_everything(opt.seed)
 
     if opt.plms:
-        sampler = PLMSSampler(model)
+        sampler = PLMSSampler(model, device)
     else:
-        sampler = DDIMSampler(model)
+        sampler = DDIMSampler(model, device)
 
     os.makedirs(opt.outdir, exist_ok=True)
     outpath = opt.outdir

--- a/prs.py
+++ b/prs.py
@@ -647,6 +647,7 @@ def do_gobig(gobig_init, gobig_scale, device, model, opt):
         finished_slices.append((finished_slice, x, y))
     final_output = grid_merge(target_image, finished_slices)
     final_output.save(f'{result}_gobig{opt.filetype}', quality = opt.quality)
+    print(opt.bucket)
     if opt.bucket:
         upload_file(f'{result}_gobig{opt.filetype}', opt.bucket)
 


### PR DESCRIPTION
This adds a --gobig_dir argument. It will scan the folder for PNG files and find the original prompt, seed, and CFG_Scale from the info stored in the pngs, then apply the gobig procedure to each file in turn.