### PR TITLE
Allow dashes in batch name

### DIFF
--- a/prs.py
+++ b/prs.py
@@ -75,8 +75,8 @@ def thats_numberwang(dir, wildcard):
     filenum = 0
     for file in files:
         if wildcard in file:
-            start = file.index('-')
-            end = file.index('.')
+            start = file.rfind('-')
+            end = file.rfind('.')
             try:
                 filenum = file[start + 1:end]
                 filenum = int(filenum)
@@ -84,7 +84,6 @@ def thats_numberwang(dir, wildcard):
                 print(f'Improperly named file "{file}" in output directory')
                 print(f'Tried to turn "{filenum}" into numberwang, but "{filenum}" is not numberwang!')
                 print(f'Please make sure output filenames use the name-1234.png format')
-                print(f'No extra bits or extra "-" characters, otherwise we cannot achieve numberwang!')
                 quit()
             filenums.append(filenum)
     if not filenums:


### PR DESCRIPTION
By replacing `index` with `rfind`, dashes can be allowed in the batch name.

I decided to change this because the files already have a dash before the iteration number, and I wanted to keep it consistent using dashes.