### PR TITLE
Fix json export for saving settings

### DIFF
--- a/prs.py
+++ b/prs.py
@@ -30,6 +30,7 @@ from k_diffusion.external import CompVisDenoiser
 
 from types import SimpleNamespace
 import json5 as json
+from json import dump
 
 try:
     # this silences the annoying "Some weights of the model checkpoint were not used when initializing..." message at start.
@@ -898,7 +899,7 @@ def save_settings(options, prompt, filenum):
         'improve_composition': options.improve_composition
     }
     with open(f"{options.outdir}/{options.batch_name}-{filenum:04}.json",  "w+", encoding="utf-8") as f:
-        json.dump(setting_list, f, ensure_ascii=False, indent=4)
+        dump(setting_list, f, ensure_ascii=False, indent=4)
 
 def esrgan_resize(input, id, esrgan_model='realesrgan-x4plus'):
     input.save(f'_esrgan_orig{id}.png')


### PR DESCRIPTION
json5 package doesn't add quotes to the keys, and this makes it hard to read in many other languages. These changes use the std json module for saving the settings. Keeps json5 for loading the settings file.

```json
{
    "prompt": "a cute ghost in a beautiful garden lit by the moonlight in the analog style",
    "checkpoint": "./models/analog-diffusion-1.0.ckpt",
    "batch_name": "analog-garden-5",
    "steps": 50,
    "eta": 0.0,
    "n_iter": 16,
    "width": 512,
    "height": 512,
    "scale": 7.0,
    "dyn": null,
    "seed": 2694855,
    "variance": 0.5,
    "init_image": null,
    "init_strength": 0.5,
    "resize_method": "basic",
    "gobig": false,
    "gobig_init": null,
    "gobig_scale": 2,
    "gobig_prescaled": false,
    "gobig_maximize": false,
    "gobig_overlap": 64,
    "gobig_keep_slices": false,
    "esrgan_model": "realesrgan-x4plus",
    "gobig_cgs": null,
    "augment_prompt": "zoomed in view of",
    "use_jpg": "false",
    "hide_metadata": false,
    "method": "k_dpmpp_2m",
    "improve_composition": false
}
```